### PR TITLE
feat: add contrast ratio compare

### DIFF
--- a/components/PalettePage.vue
+++ b/components/PalettePage.vue
@@ -1,15 +1,23 @@
 <script setup>
+import Check from '~/icons/Check.vue'
 import { useImage } from '~/composables/useImage.js'
+import { useContrastRatio } from '~/composables/useContrastRatio.ts'
 
 const { colors, imageUrl } = useImage()
+const { contrastRatio, markSelectedColor, checkIfColorSelected } = useContrastRatio()
 </script>
+
 <template>
   <div v-if="imageUrl" class="flex justify-content-center py-4">
     <img :src="imageUrl" alt="Uploaded Image Preview" class="w-96 aspect-auto" />
   </div>
   <div class="flex justify-content-center pt-4">
-    <div v-for="(color, index) in colors" :key="index" class="size-30 font-bold flex items-center justify-center" :style="{ backgroundColor: color }">
-      <span class="mix-blend-exclusion">{{color}}</span>
-    </div>
+    <button @click="() => markSelectedColor(color)" v-for="(color, index) in colors" :key="index" class="relative size-30 font-bold flex items-center justify-center" :style="{ backgroundColor: color.hex }" aria-label="{{ checkIfColorSelected(color) ? 'Deselect' : 'Select' }} color with hex code {{ color.hex }} }}">
+      <div class="absolute top-1 right-1">
+         <Check v-if="checkIfColorSelected(color)" /> 
+      </div>
+      <span class="mix-blend-exclusion">{{color.hex}}</span>
+    </button>
   </div>
+  <div v-if="contrastRatio !== undefined">Contrast Ratio: {{ contrastRatio }}</div>
 </template>

--- a/components/PalettePage.vue
+++ b/components/PalettePage.vue
@@ -13,9 +13,7 @@ const { contrastRatio, markSelectedColor, checkIfColorSelected } = useContrastRa
   </div>
   <div class="flex justify-content-center pt-4">
     <button @click="() => markSelectedColor(color)" v-for="(color, index) in colors" :key="index" class="relative size-30 font-bold flex items-center justify-center" :style="{ backgroundColor: color.hex }" aria-label="{{ checkIfColorSelected(color) ? 'Deselect' : 'Select' }} color with hex code {{ color.hex }} }}">
-      <div class="absolute top-1 right-1">
-         <Check v-if="checkIfColorSelected(color)" /> 
-      </div>
+      <Check v-if="checkIfColorSelected(color)" className="absolute top-1 right-1 w-6 h-6" /> 
       <span class="mix-blend-exclusion">{{color.hex}}</span>
     </button>
   </div>

--- a/composables/useContrastRatio.ts
+++ b/composables/useContrastRatio.ts
@@ -1,0 +1,38 @@
+import { computed } from "vue"
+import { getContrastRatio } from "~/utils/colors"
+
+const MAX_NUMBER_COLORS_TO_COMPARE = 2
+
+type ColorObject = {
+  hex: string
+  rgb: number[]
+}
+
+export const useContrastRatio = () => {
+  const selectedColors = useState<ColorObject[]>('selectedColors', () => [])
+  const contrastRatio = computed(() => {
+    if (selectedColors.value.length < MAX_NUMBER_COLORS_TO_COMPARE) return 
+    return getContrastRatio(selectedColors.value[0].rgb, selectedColors.value[1].rgb).toFixed(2)
+  })
+
+  const checkIfColorSelected = (color: ColorObject) => {
+    return Boolean(selectedColors.value.find(c => c.hex === color.hex))
+  }
+
+  const markSelectedColor = (color: ColorObject) => {
+    const colorExists = checkIfColorSelected(color)
+
+    if (colorExists) {
+      selectedColors.value = selectedColors.value.filter(c => c.hex !== color.hex)
+      return
+    }
+
+    if (selectedColors.value.length >= MAX_NUMBER_COLORS_TO_COMPARE) {
+      selectedColors.value.pop()
+    }
+
+    selectedColors.value.push(color)   
+  }
+
+  return { selectedColors, markSelectedColor, contrastRatio, checkIfColorSelected }
+}

--- a/composables/useImage.js
+++ b/composables/useImage.js
@@ -4,16 +4,14 @@ export const useImage = () => {
 	const imageUrl = useState("imageUrl", () => null);
 	const colors = useState("colors", () => []);
 
-	const rgbToHex = (colors) =>
-		colors.map(
-			([r, g, b]) =>
-				`#${[r, g, b]
-					.map((x) => {
-						const hex = x.toString(16);
-						return hex.length === 1 ? `0${hex}` : hex;
-					})
-					.join("")}`,
-		);
+	const rgbToHex = (rgbArr) => {
+		const hexParts = rgbArr.map(colorValue => {
+		  const hexChunk = colorValue.toString(16);
+			return hexChunk.length === 1 ? `0${hexChunk}` : hexChunk;
+		})
+
+		return `#${hexParts.join("")}`;
+	};
 
 	const setImageUrl = (newImageUrl) => {
 		imageUrl.value = newImageUrl;
@@ -24,8 +22,13 @@ export const useImage = () => {
 		img.onload = () => {
 			const colorThief = new ColorThief();
 			const extractedColors = colorThief.getPalette(img, 5);
-			colors.value = rgbToHex(extractedColors);
-		};
+			colors.value = extractedColors.map(rgb => {
+				return {
+					hex: rgbToHex(rgb),
+					rgb
+				}
+			})
+		};	
 		img.src = imageSrc;
 		img.crossOrigin = "Anonymous";
 	};

--- a/icons/Check.vue
+++ b/icons/Check.vue
@@ -1,11 +1,16 @@
 <template>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" :class="className">
     <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
   </svg>
 </template>
 
-<script lang="ts">
-export default {
-  name: 'Check',
-}
+<script setup lang="ts">
+import { defineProps } from 'vue'
+
+const { className } = defineProps({
+  className: {
+    type: String,
+    default: 'w-6 h-6'
+  }
+})
 </script>

--- a/icons/Check.vue
+++ b/icons/Check.vue
@@ -1,0 +1,11 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+  </svg>
+</template>
+
+<script lang="ts">
+export default {
+  name: 'Check',
+}
+</script>

--- a/utils/colors.ts
+++ b/utils/colors.ts
@@ -1,0 +1,25 @@
+export function getLuminance(rgb: number[]) {
+  // Reference on how these values are being
+  // computed: https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-procedure
+  const RED = 0.2126
+  const GREEN = 0.7152
+  const BLUE = 0.0722
+  const GAMMA = 2.4
+
+  const [r, g, b] = rgb.map(colorValue => {
+    colorValue /= 255
+    return colorValue <= 0.03928 
+      ? colorValue / 12.92 
+      : Math.pow((colorValue + 0.055) / 1.055, GAMMA)
+  })
+
+  return (RED * r) + (GREEN * g) + (BLUE * b)
+}
+
+export function getContrastRatio(firstRgb: number[], secondRgb: number[]) {
+  const firstLuminance = getLuminance(firstRgb)
+  const secondLuminance = getLuminance(secondRgb)
+  const brightest = Math.max(firstLuminance, secondLuminance)
+  const darkest = Math.min(firstLuminance, secondLuminance)
+  return (brightest + 0.05) / (darkest + 0.05)
+}


### PR DESCRIPTION
## Overview

Now you're able to select 2 colors from the uploaded image's generated palette and compare the contrast ratio between them. The contrast ratio will only be calculated and displayed when 2 colors are selected. 

## Screenshot
<img width="1424" alt="Screen Shot 2024-02-09 at 4 05 45 AM" src="https://github.com/linuxmobile/palettePilot/assets/89048183/2699e564-7b2e-4747-806c-5f40be9b5683">