### PR TITLE
refactor: use global generic state

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -20,12 +20,12 @@ useSeoMeta({
   twitterCard: 'summary_large_image'
 })
 
-const { imageSrc, colors } = useImage()
+const { imageSrc } = useImage()
 </script>
 <template>
   <Header />
   <div class="flex flex-col items-center justify-center">
-    <Home v-if="!imageSrc" />
+    <Home v-if="imageSrc === ''" />
     <PalettePage v-else />
   </div>
 </template>

--- a/composables/useColorSelection.ts
+++ b/composables/useColorSelection.ts
@@ -1,17 +1,10 @@
+import { useGlobalGenericState } from "~/utils/useGlobalGenericState";
 import { type ColorWithRgbAndHex } from "~/types/colors";
 
 export const useColorSelection = (initialColors: ColorWithRgbAndHex[]) => {
-	const primaryColor = useState<ColorWithRgbAndHex | undefined>("primaryColor", () => initialColors?.[0]);
-	const accentColor = useState<ColorWithRgbAndHex | undefined>("accentColor", () => initialColors?.[1]);
-
-	const selectPrimaryColor = (color: ColorWithRgbAndHex): void => {
-		primaryColor.value = color;
-	};
-
-	const selectAccentColor = (color: ColorWithRgbAndHex): void => {
-		accentColor.value = color;
-	};
-
+	const [primaryColor, selectPrimaryColor] = useGlobalGenericState("primaryColor", initialColors?.at(0));
+	const [accentColor, selectAccentColor] = useGlobalGenericState("accentColor", initialColors?.at(1));
+	
 	const swapColors = (): void => {
 		[primaryColor.value, accentColor.value] = [
 			accentColor.value,
@@ -20,10 +13,10 @@ export const useColorSelection = (initialColors: ColorWithRgbAndHex[]) => {
 	};
 
 	return {
-		swapColors,
-		selectPrimaryColor,
-		selectAccentColor,
 		primaryColor,
 		accentColor,
+		selectPrimaryColor,
+		selectAccentColor,
+	  swapColors,
 	};
 };

--- a/composables/useImage.ts
+++ b/composables/useImage.ts
@@ -1,6 +1,6 @@
 import { useGlobalGenericState } from "~/utils/useGlobalGenericState";
 
 export const useImage = () => {
-	const [imageSrc, setImageSrc] = useGlobalGenericState<string | null>("imageSrc", null)
+	const [imageSrc, setImageSrc] = useGlobalGenericState("imageSrc", "")
 	return { imageSrc, setImageSrc }
 };

--- a/composables/useImage.ts
+++ b/composables/useImage.ts
@@ -1,9 +1,6 @@
+import { useGlobalGenericState } from "~/utils/useGlobalGenericState";
+
 export const useImage = () => {
-	const imageSrc = useState<string | null>("imageSrc", () => null);
-
-	const setImageSrc = (newImageSrc: string): void => {
-		imageSrc.value = newImageSrc;
-	};
-
-	return { imageSrc, setImageSrc };
+	const [imageSrc, setImageSrc] = useGlobalGenericState<string | null>("imageSrc", null)
+	return { imageSrc, setImageSrc }
 };

--- a/composables/useImageColors.ts
+++ b/composables/useImageColors.ts
@@ -1,11 +1,7 @@
+import { useGlobalGenericState } from "~/utils/useGlobalGenericState";
 import { type ColorWithRgbAndHex } from "~/types/colors";
 
 export const useImageColors = () => {
-	const imageColors = useState<ColorWithRgbAndHex[]>("colors", () => []);
-
-	const setImageColors = (colors: ColorWithRgbAndHex[]) => {
-		imageColors.value = colors
-	}
-
+	const [imageColors, setImageColors] = useGlobalGenericState<ColorWithRgbAndHex[]>("imageColors", [])
 	return { imageColors, setImageColors }
 }

--- a/utils/useGlobalGenericState.ts
+++ b/utils/useGlobalGenericState.ts
@@ -1,0 +1,9 @@
+export const useGlobalGenericState = <TState>(stateKey: string, initialState: TState) => {
+  const state = useState<TState>(stateKey, () => initialState);
+  
+  const setState = (newValue: TState) => {
+    state.value = newValue
+  }
+
+  return [state, setState] as const
+}


### PR DESCRIPTION
Avoid code repetition when creating new global states. More precisely, the logic to create a new global state and declare a function to update its value. 