### PR TITLE
feat: add alert dialog ui example element

### DIFF
--- a/components/UIComponents.vue
+++ b/components/UIComponents.vue
@@ -2,6 +2,7 @@
 import MemberCard from '~/components/uicomponents/MemberCard.vue'
 import GithubRepo from '~/components/uicomponents/GithubRepo.vue'
 import ListenNow from '~/components/uicomponents/ListenNow.vue'
+import AlertDialog from '~/components/uicomponents/AlertDialog.vue'
 </script>
 <template>
   <main
@@ -15,6 +16,9 @@ import ListenNow from '~/components/uicomponents/ListenNow.vue'
     </section>
     <section class="md:col-span-3">
       <ListenNow />
+    </section>
+    <section class="md:col-span-3">
+      <AlertDialog />
     </section>
   </main>
 </template>

--- a/components/uicomponents/AlertDialog.vue
+++ b/components/uicomponents/AlertDialog.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useColorSelection } from '~/composables/useColorSelection'
+import { useImageColors } from '~/composables/useImageColors'
+
+const isDialogOpen = ref(false)
+const { imageColors } = useImageColors()
+const { accentColor, primaryColor } = useColorSelection(imageColors.value)
+const bg = computed(() => primaryColor?.value?.hex ?? '#000000')
+const fg = computed(() => accentColor?.value?.hex ?? '#000000')
+
+const openDialog = () => {
+  isDialogOpen.value = true
+}
+
+const closeDialog = () => {
+  isDialogOpen.value = false
+}
+
+// TODO: determine bg luminance in order to set an appropriate border color for the button
+// TODO: determine bg luminance in order to set an appropriate neutral text color for alert dialog
+// (using fg meanwhile)
+// TODO: determine bg luminance in order to set an appropriate bg color for alert dialog's inner buttons
+// and also, get the luminance of that bg color to select an appropriate text color
+</script>
+
+<template>
+  <button
+    class="text-sm font-semibold py-2 px-8 border border-zinc-700 rounded-md"
+    @click="openDialog"
+    :style="{ backgroundColor: bg, color: fg }"
+  >
+    Show alert dialog
+  </button>
+  <div
+    v-if="isDialogOpen"
+    role="alertdialog"
+    aria-live="assertive"
+    class="grid place-content-center absolute inset-0 bg-black/60 z-24"
+  >
+    <div
+      class="flex flex-col gap-3 py-3 px-4 border border-zinc-600 rounded-md"
+      :style="{ backgroundColor: bg }"
+    >
+      <p class="font-bold text-base lg:text-lg" :style="{ color: fg }">
+        Are you sure?
+      </p>
+      <p class="text-xs lg:text-sm font-light" :style="{ color: fg }">
+        This action is permanent, you won't be able to undo it.
+      </p>
+      <div class="flex flex-wrap items-center justify-end gap-3 mt-5">
+        <button
+          class="text-sm font-semibold py-2 px-8 border border-zinc-700 rounded-md"
+          @click="closeDialog"
+          :style="{ color: fg }"
+        >
+          Cancel
+        </button>
+        <button
+          class="text-sm font-semibold py-2 px-8 border border-zinc-700 rounded-md"
+          :style="{ backgroundColor: bg, color: fg }"
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Notes:
Luminance of primary color should be calculated in order to choose appropriate colors for borders, inner dialog's neutrals, inner dialog button's neutrals and bg colors.

## Screenshots
<img width="1422" alt="Screen Shot 2024-02-17 at 7 53 26 PM" src="https://github.com/linuxmobile/palettePilot/assets/89048183/988a9037-c59b-498e-99ec-1fa98ffa2092">
