### PR TITLE
fix: check for file size on client

### DIFF
--- a/components/FileUpload.vue
+++ b/components/FileUpload.vue
@@ -3,6 +3,7 @@ import { useImage } from '~/composables/useImage'
 import { useColors } from '~/composables/useColors'
 import { extractColorsFromImage } from '~/utils/colors'
 import { stripError } from '~/utils/errors'
+import { MAX_BYTES_SIZE } from '~/consts/files'
 
 const { imageSrc, setImageSrc } = useImage()
 const { imageColors, setImageColors, selectPrimaryColor, selectAccentColor } =
@@ -18,6 +19,11 @@ const onUpload = async (event: Event) => {
   const target = event.target as HTMLInputElement
   const file = target.files !== null ? target.files[0] : null
   if (file == null) return
+
+  if (file.size > MAX_BYTES_SIZE) {
+    errorMsg.value = 'Image is too big! Max size: 4.5MB'
+    return
+  }
 
   isLoading.value = true
   errorMsg.value = ''

--- a/consts/files.ts
+++ b/consts/files.ts
@@ -1,0 +1,1 @@
+export const MAX_BYTES_SIZE = 4500000 // 4.5 MB

--- a/server/api/palettes/save.post.ts
+++ b/server/api/palettes/save.post.ts
@@ -2,8 +2,7 @@ import { uploadImageFromBase64 } from '~/lib/cloudinary'
 import { kv } from '~/lib/db'
 import { hashImageBase64 } from '~/utils/images'
 import { log } from '~/lib/logs'
-
-const MAX_BYTES_SIZE = 4500000 // 4.5 MB
+import { MAX_BYTES_SIZE } from '~/consts/files'
 
 export default eventHandler(async event => {
   const formData = await readMultipartFormData(event)


### PR DESCRIPTION
When in production, the point where the server throws an exception because of the large file size is never reached. Because of that, it's necessary to also do the check on the client-side before making the request.