### PR TITLE
UI Components styles fixed

### DIFF
--- a/components/UIComponents.vue
+++ b/components/UIComponents.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="pt-12 w-full h-full px-3 pb-6 grid content-start grid-cols-8 gap-x-4 gap-y-3 select-none z-[1]"
+    class="pt-12 w-full h-full px-3 pb-6 grid content-start grid-cols-8 2xl:grid-cols-9 gap-x-4 gap-y-3 select-none z-[1]"
   >
     <section class="col-span-full md:col-span-4 2xl:col-span-3 flex flex-col gap-y-3">
       <uicomponentsMemberCard />

--- a/components/UIComponents.vue
+++ b/components/UIComponents.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="pt-12 w-full h-full px-3 pb-6 grid content-start grid-cols-9 gap-x-4 gap-y-3 select-none"
+    class="pt-12 w-full h-full px-3 pb-6 grid content-start grid-cols-8 gap-x-4 gap-y-3 select-none z-[1]"
   >
     <section class="col-span-full md:col-span-4 2xl:col-span-3 flex flex-col gap-y-3">
       <uicomponentsMemberCard />


### PR DESCRIPTION
- work with us "floating" over the header
![image](https://github.com/linuxmobile/palettePilot/assets/67347256/17957ddb-8a71-421b-b7fe-2e2cc3f83a44)
- blank space in right side
![image](https://github.com/linuxmobile/palettePilot/assets/67347256/73233d5f-714f-426b-b1ed-7836cefc1e66)

Fixed result 
![image](https://github.com/linuxmobile/palettePilot/assets/67347256/54cb363b-fc37-4b71-8563-55a2d9372294)
![image](https://github.com/linuxmobile/palettePilot/assets/67347256/e2a56250-dd06-4f26-b207-3d965415c58e)
