### PR TITLE
Refactor kv structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "format": "prettier --write '**/*.{js,ts,vue}'"
+    "format": "prettier --write '**/*.{js,ts,vue}'",
+    "clear-resources": "bun scripts/clear-resources.js"
   },
   "dependencies": {
     "@ivnatsr/color-logs": "1.0.3",

--- a/scripts/clear-resources.js
+++ b/scripts/clear-resources.js
@@ -1,0 +1,19 @@
+import { kv } from '@vercel/kv'
+import { v2 as cloudinary } from 'cloudinary'
+import { log } from '~/lib/logs'
+
+cloudinary.api
+  .delete_all_resources()
+  .then(() => {
+    log('info', '✅ Cloudinary resources deleted successfully')
+  })
+  .catch(error => {
+    log(
+      'error',
+      `❌ Error while deleting Cloudinary resources: [${error.message.toUpperCase()}]`
+    )
+  })
+
+kv.flushdb().then(() => {
+  log('info', '✅ KV entries deleted successfully')
+})

--- a/server/api/palettes/[hash].get.ts
+++ b/server/api/palettes/[hash].get.ts
@@ -1,72 +1,54 @@
 import { kv } from '~/lib/db'
 import { log } from '~/lib/logs'
 import { type ColorWithRgbAndHex } from '~/types/colors'
+import { type KvGetItemResponse } from '~/types/api'
 
 interface Params {
   hash?: string
 }
 
 interface ApiResponse {
-  imageUrl: string | null
-  colors: ColorWithRgbAndHex[] | null
+  imageUrl: string
+  colors: ColorWithRgbAndHex[]
 }
 
 export default eventHandler(async (event): Promise<ApiResponse> => {
   const params: Params | undefined = event.context.params
-  log('info', `⏱ Retrieving image with hash: ${params?.hash}...`)
+  log('info', `⏱ Retrieving image data associated to hash: ${params?.hash}...`)
 
-  const storedImageUrl: string | null =
-    (
-      await kv.getItem(params?.hash ?? '').catch(error => {
-        if (error instanceof Error) {
-          log(
-            'error',
-            `❌ Something went wrong retrieving the image from KV store...[${error.message.toUpperCase()}]`
-          )
-          throw createError({
-            statusCode: 500,
-            statusMessage: 'Something went wrong... Try again!'
-          })
-        }
+  const imageData = (await kv.getItem(params?.hash ?? '').catch(error => {
+    if (error instanceof Error) {
+      log(
+        'error',
+        `❌ Something went wrong retrieving the image data from KV store...[${error.message.toUpperCase()}]`
+      )
+      throw createError({
+        statusCode: 500,
+        statusMessage: 'Something went wrong... Try again!'
       })
-    )?.toString() ?? null
+    }
+  })) as KvGetItemResponse | null
 
-  if (storedImageUrl === null) {
-    log('error', '❌ Image not found in KV store...')
+  if (imageData === null) {
+    log('error', '❌ Image data not found in KV store...')
     throw createError({
       statusCode: 404,
-      statusMessage: 'Image for this palette does not exist. Try creating one!'
+      statusMessage: 'No data found for this palette. Try creating one!'
     })
   }
 
-  const colorsKey: string = `${params?.hash}_colors`
-  const storedColorsString: string | null =
-    (
-      await kv.getItem(colorsKey).catch(() => {
-        log(
-          'error',
-          `❌ Something went wrong retrieving the colors from KV store for hash: ${colorsKey}...`
-        )
-      })
-    )?.toString() ?? null
+  const { url, colors } = imageData
 
-  let colors: ColorWithRgbAndHex[] | null = null
-  if (storedColorsString != null) {
-    colors = storedColorsString
-      .split(';')
-      .map((colorStr): ColorWithRgbAndHex => {
-        const [hex, rgbStr] = colorStr.split('_')
-        const rgb: number[] = rgbStr
-          .split('-')
-          .map((num): number => parseInt(num, 10))
-        return { hex, rgb }
-      })
-  }
+  const parsedColors: ColorWithRgbAndHex[] = colors.split(';').map(colorStr => {
+    const [hex, rgbStr] = colorStr.split('_')
+    const rgb = rgbStr.split('-').map((num): number => parseInt(num, 10))
+    return { hex, rgb }
+  })
 
-  log('info', '✅ Image and colors found. Retrieving from KV store...')
+  log('info', '✅ Image data found. Returning it from KV store...')
 
   return {
-    imageUrl: storedImageUrl,
-    colors
+    imageUrl: url,
+    colors: parsedColors
   }
 })

--- a/server/api/palettes/[hash].get.ts
+++ b/server/api/palettes/[hash].get.ts
@@ -39,16 +39,10 @@ export default eventHandler(async (event): Promise<ApiResponse> => {
 
   const { url, colors } = imageData
 
-  const parsedColors: ColorWithRgbAndHex[] = colors.split(';').map(colorStr => {
-    const [hex, rgbStr] = colorStr.split('_')
-    const rgb = rgbStr.split('-').map((num): number => parseInt(num, 10))
-    return { hex, rgb }
-  })
-
   log('info', '✅ Image data found. Returning it from KV store...')
 
   return {
     imageUrl: url,
-    colors: parsedColors
+    colors
   }
 })

--- a/server/api/palettes/save.post.ts
+++ b/server/api/palettes/save.post.ts
@@ -72,18 +72,10 @@ export default eventHandler(async event => {
     )
     const { url, colors } = imageData
 
-    const colorsArray: ColorWithRgbAndHex[] = colors
-      .split(';')
-      .map(colorStr => {
-        const [hex, rgbStr] = colorStr.split('_')
-        const rgb = rgbStr.split('-').map(num => parseInt(num, 10))
-        return { hex, rgb }
-      })
-
     return {
       imageHash,
       imageUrl: url,
-      colors: colorsArray
+      colors
     }
   }
 
@@ -92,11 +84,8 @@ export default eventHandler(async event => {
       'info',
       '💾 Image data does not exist. Uploading image and saving its data in KV store...'
     )
-    const colorsString = colorsFromReq
-      .map(color => `${color.hex}_${color.rgb.join('-')}`)
-      .join(';')
     const imageUrl = await uploadImageFromBase64(base64Image)
-    await kv.setItem(imageHash, { url: imageUrl, colors: colorsString })
+    await kv.setItem(imageHash, { url: imageUrl, colors: colorsFromReq })
 
     log('info', '✅ Image data saved in KV store...')
 

--- a/server/api/palettes/save.post.ts
+++ b/server/api/palettes/save.post.ts
@@ -4,6 +4,7 @@ import { hashImageBase64 } from '~/utils/images'
 import { log } from '~/lib/logs'
 import { MAX_BYTES_SIZE } from '~/consts/files'
 import { type ColorWithRgbAndHex } from '~/types/colors'
+import { type KvGetItemResponse } from '~/types/api'
 
 export default eventHandler(async event => {
   const formData = await readMultipartFormData(event)
@@ -26,9 +27,9 @@ export default eventHandler(async event => {
     })
   }
 
-  const colors: ColorWithRgbAndHex[] = JSON.parse(colorsData.toString())
+  const colorsFromReq: ColorWithRgbAndHex[] = JSON.parse(colorsData.toString())
 
-  if (!Array.isArray(colors)) {
+  if (!Array.isArray(colorsFromReq)) {
     log('error', '❌ Expected an array of rgb and hex color objects...')
     throw createError({
       statusCode: 400,
@@ -51,67 +52,64 @@ export default eventHandler(async event => {
   const base64Image = file.data.toString()
   const imageHash = hashImageBase64(base64Image)
 
-  const storedImageUrl = await kv.getItem(imageHash)
-  if (storedImageUrl !== null) {
-    log('info', '✅ Image already exists. Returning it as is from KV store...')
+  const imageData = (await kv.getItem(imageHash).catch(error => {
+    if (error instanceof Error) {
+      log(
+        'error',
+        `❌ Error while getting image data from KV store: [${error.message.toUpperCase()}]`
+      )
+      throw createError({
+        statusCode: 500,
+        statusMessage: 'Could not process the request. Try again!'
+      })
+    }
+  })) as KvGetItemResponse | null
 
-    const storedColorsString = await kv.getItem(`${imageHash}_colors`)
-    if (typeof storedColorsString === 'string') {
-      const colorsArray = storedColorsString.split(';').map(colorStr => {
+  if (imageData !== null) {
+    log(
+      'info',
+      '✅ Image data already exists. Returning it as is from KV store...'
+    )
+    const { url, colors } = imageData
+
+    const colorsArray: ColorWithRgbAndHex[] = colors
+      .split(';')
+      .map(colorStr => {
         const [hex, rgbStr] = colorStr.split('_')
         const rgb = rgbStr.split('-').map(num => parseInt(num, 10))
         return { hex, rgb }
       })
 
-      log(
-        'info',
-        '✅ Colors already exist. Returning them as is from KV store...'
-      )
-      return {
-        imageHash,
-        imageUrl: storedImageUrl,
-        colors: colorsArray
-      }
-    }
-
-    log('info', '🎨 Colors do not exist. Storing them now...')
-    const colorsString = colors
-      .map(color => `${color.hex}_${color.rgb.join('-')}`)
-      .join(';')
-    await kv.setItem(`${imageHash}_colors`, colorsString)
-    log('info', '✅ Colors stored successfully.')
     return {
       imageHash,
-      imageUrl: storedImageUrl,
-      colors
+      imageUrl: url,
+      colors: colorsArray
     }
   }
 
   try {
     log(
       'info',
-      '💾 Image does not exist. Uploading it and saving it in KV store...'
+      '💾 Image data does not exist. Uploading image and saving its data in KV store...'
     )
-    const imageUrl = await uploadImageFromBase64(base64Image)
-    await kv.setItem(imageHash, imageUrl)
-
-    log('info', `🎨 Storing colors for imageHash: ${imageHash}...`)
-    const colorsString = colors
+    const colorsString = colorsFromReq
       .map(color => `${color.hex}_${color.rgb.join('-')}`)
       .join(';')
-    await kv.setItem(`${imageHash}_colors`, colorsString)
+    const imageUrl = await uploadImageFromBase64(base64Image)
+    await kv.setItem(imageHash, { url: imageUrl, colors: colorsString })
 
-    log('info', '✅ Image and colors uploaded and saved in KV store...')
+    log('info', '✅ Image data saved in KV store...')
+
     return {
       imageHash,
       imageUrl,
-      colors
+      colors: colorsFromReq
     }
   } catch (error) {
     if (error instanceof Error) {
       log(
         'error',
-        `❌ Error while uploading image and saving colors: ${error.message}`
+        `❌ Error while saving image data: [${error.message.toUpperCase()}]`
       )
     }
     throw createError({

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,4 @@
+export type KvGetItemResponse = {
+  url: string
+  colors: string
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,4 +1,6 @@
+import { type ColorWithRgbAndHex } from './colors'
+
 export type KvGetItemResponse = {
   url: string
-  colors: string
+  colors: ColorWithRgbAndHex[]
 }


### PR DESCRIPTION
## Why 

Before this change, the images' URLs from which the palettes are generated and the resulting generated colors were being stored separately with different keys. 

This approach led to unnecessary requests to the KV store and harder to read code, since you had to make sure BOTH the entry for the image url AND the entry for the colors that belong to that image's palette exist in the store.

## Proposed solution

Store all related data under the same key in the KV store so we don't make extra requests to the store and simplify the existing code, since we will know for sure that if an image is uploaded and saved in the KV store, so will be the palette colors.